### PR TITLE
Gmail iPadOS

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,3 +1,6 @@
+Alice Li:
+  name: Alice Li
+  url: https://twitter.com/AliceLiCode
 Arfon Davis:
   name: Arfon Davis
   url: https://twitter.com/arfon

--- a/hacks/_posts/2023-11-13-gmail-ipad
+++ b/hacks/_posts/2023-11-13-gmail-ipad
@@ -1,0 +1,19 @@
+---
+client: Gmail
+version: 17.1.1
+platform: iPadOS
+status: Working
+languages:
+  - CSS
+contributor: Alice Li
+---
+
+```css
+@media only screen and (min-device-width: 768px) and (max-device-width: 1366px) {
+  u + .body .your-class-name {
+    /* Replace this comment with your styles */
+  }
+}
+```
+
+Media queries detect the device size to filter out iPhones and Gmail Webmail.


### PR DESCRIPTION
Adding Gmail for iPadOS. Note: This targets only Gmail for iPadOS from my testing, but Litmus shows that it targets Gmail Webmail too. In live Gmail webmail tests, it does not get targeted.