### PR TITLE
Remove version

### DIFF
--- a/hacks/_posts/2023-11-13-gmail-ipad.md
+++ b/hacks/_posts/2023-11-13-gmail-ipad.md
@@ -1,6 +1,6 @@
 ---
 client: Gmail
-version: 17.1.1
+version:
 platform: iPadOS
 status: Working
 languages:


### PR DESCRIPTION
Removed the iPadOS version because it's showing up on the site as the Gmail version instead and could look confusing.