### PR TITLE
Exclusively target Outlook webmail using chained class names

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -4,6 +4,9 @@ Alice Li:
 Arfon Davis:
   name: Arfon Davis
   url: https://twitter.com/arfon
+Cyrill Gross:
+  name: Cyrill Gross
+  url: https://cygro.ch
 Devika Sujith:
   name: Devika Sujith
   url: https://twitter.com/deecoder21

--- a/hacks/_posts/2025-03-28-outlook-webmail.md
+++ b/hacks/_posts/2025-03-28-outlook-webmail.md
@@ -1,0 +1,27 @@
+---
+lient: Outlook
+version:
+platform: webmail
+status: Working
+languages:
+  - CSS
+contributor: Cyrill Gross
+---
+
+```css
+.your-class-name.x_chained-class-name {
+  /* Styles for outlook webmail only */
+}
+.your-class-name.chained-class-name {
+  /* Styles for everyone else */
+}
+```
+
+```html
+<div class="your-class-name chained-class-name">
+  <!-- Your code -->
+</div>
+```
+
+Outlook webmail (desktop and mobile) prefixes all class names with `x_`. It does this in the class attribute of html elements as well as class definitions in `<style>` blocks. However, in the `<style>` blocks it does it only on the first class name of chained classes: `.your-class-name.x_chained-class-name` will be changed to `.x_your-class-name.x_chained-class-name`. On the element `<div class="your-class-name chained-class-name">` will be changed to `<div class="x_your-class-name x_chained-class-name">` by Outlook webmails pre processor. 
+This approach allows us to build a exclusive targeting which is helpful to tackle the `box-sizing:border-box !important;` style attribute which Outlook webmail adds on elements having widht / height AND paddings defined as we can set the width / heigth for border-box calculation for Outlook webmail only.


### PR DESCRIPTION
Handy to tackle the "box-sizing: border-box !important;" style added by the pre-processor on elements having width/height and padding set.
